### PR TITLE
only overwrite wireguard key on gateway if not present

### DIFF
--- a/src/gateway-link/entrypoint.sh
+++ b/src/gateway-link/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-WG_PRIVKEY=$(wg genkey)
-echo $WG_PRIVKEY > /etc/wireguard/link0.key
-
+# only generate a new key if link0.key is missing or empty
+if ! [[ -s /etc/wireguard/link0.key ]]; then
+    WG_PRIVKEY=$(wg genkey)
+    echo $WG_PRIVKEY > /etc/wireguard/link0.key
+fi
 
 ip link add link0 type wireguard
 


### PR DESCRIPTION
Tested working w/o the need for a docker volume, key persists past container restart. 

Still needs #2 to pin the port number on restart or connection can't be re-established. For now, manually updating the endpoint in client-link after restarting the container works to verify it's possible to re-establish the connection.