### PR TITLE
pin random container port to container to survive reboots

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This project automates the provisioning of a **Reverse Proxy-over-VPN (RPoVPN)**
   - Open ports 80/443 (http(s)).
   - UDP port range listed `/proc/sys/net/ipv4/ip_local_port_range` exposed to the internet.
   - SSH access to the `gateway`.
-  - `docker`, `git` & `make` installed.
+  - `docker`, `git`, `jq`, & `make` installed.
 - Server with one or more services defined in a `docker-compose.yml` that you would like to expose to the internet.
 - A local machine to run the commands on. This may also be the server where the exposed services will run.
   - `docker`, `git` & `make` installed on the local machine.

--- a/src/create-link/remote.sh
+++ b/src/create-link/remote.sh
@@ -5,22 +5,17 @@ set -e
 CONTAINER_NAME=$1
 LINK_CLIENT_WG_PUBKEY=$2
 
+# get local port range
+read LOWER_PORT UPPER_PORT < /proc/sys/net/ipv4/ip_local_port_range
+# credit: https://unix.stackexchange.com/a/423052
+# compare active udp ports against local port range, select an open port at random
+WIREGUARD_PORT=$(comm -23 <(seq $LOWER_PORT $UPPER_PORT | sort) <(ss -Huan | awk '{print $4}' | cut -d':' -f2 | sort -u) | shuf | head -1)
+
 # create gateway-link container
-CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p 18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
+CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p $WIREGUARD_PORT:18521/udp --cap-add NET_ADMIN --restart unless-stopped -it -e LINK_CLIENT_WG_PUBKEY=$LINK_CLIENT_WG_PUBKEY -d fractalnetworks/gateway-link:latest)
 # get gateway-link WireGuard pubkey 
 GATEWAY_LINK_WG_PUBKEY=$(docker exec $CONTAINER_NAME bash -c 'cat /etc/wireguard/link0.key |wg pubkey')
-# get randomly assigned WireGuard port
-WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.0\.0://")
-
-# hacky pin randomly selected docker port as persistent by editing container hostconfig.json to persist config through reboots
-CONTAINER_CONFIG_PATH=$(docker inspect $CONTAINER_NAME | jq -r '.[]| ."HostsPath"' | xargs dirname)
-docker stop "$CONTAINER_NAME" 1>/dev/null 2>&1
-jq --arg PORT "$WIREGUARD_PORT" '(."PortBindings"."18521/udp"[] | ."HostPort" ) |= $PORT' "$CONTAINER_CONFIG_PATH/hostconfig.json" > "$CONTAINER_CONFIG_PATH/hostconfig.json.tmp"
-mv "$CONTAINER_CONFIG_PATH/hostconfig.json.tmp" "$CONTAINER_CONFIG_PATH/hostconfig.json"
-docker start "$CONTAINER_NAME" 1>/dev/null 2>&1
-
 # get public ipv4 address
 GATEWAY_IP=$(curl -s 4.icanhazip.com)
 
 echo "$GATEWAY_LINK_WG_PUBKEY $GATEWAY_IP:$WIREGUARD_PORT"
-

--- a/src/create-link/remote.sh
+++ b/src/create-link/remote.sh
@@ -11,6 +11,14 @@ CONTAINER_ID=$(docker run --name $CONTAINER_NAME --network gateway -p 18521/udp 
 GATEWAY_LINK_WG_PUBKEY=$(docker exec $CONTAINER_NAME bash -c 'cat /etc/wireguard/link0.key |wg pubkey')
 # get randomly assigned WireGuard port
 WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.0\.0://")
+
+# hacky pin randomly selected docker port as persistent by editing container hostconfig.json to persist config through reboots
+CONTAINER_CONFIG_PATH=$(docker inspect $CONTAINER_NAME | jq -r '.[]| ."HostsPath"' | xargs dirname)
+docker stop "$CONTAINER_NAME"
+jq --arg PORT "$WIREGUARD_PORT" --arg PORTSEL "${WIREGUARD_PORT}/udp" '(."PortBindings" | .[$PORTSEL] | .[] | ."HostPort" ) |= $PORT' "$CONTAINER_CONFIG_PATH/hostconfig.json" > "$CONTAINER_CONFIG_PATH/hostconfig.json.tmp"
+mv "$CONTAINER_CONFIG_PATH/hostconfig.json.tmp" "$CONTAINER_CONFIG_PATH/hostconfig.json"
+docker start "$CONTAINER_NAME"
+
 # get public ipv4 address
 GATEWAY_IP=$(curl -s 4.icanhazip.com)
 

--- a/src/create-link/remote.sh
+++ b/src/create-link/remote.sh
@@ -14,10 +14,10 @@ WIREGUARD_PORT=$(docker port $CONTAINER_NAME 18521/udp| head -n 1| sed "s/0\.0\.
 
 # hacky pin randomly selected docker port as persistent by editing container hostconfig.json to persist config through reboots
 CONTAINER_CONFIG_PATH=$(docker inspect $CONTAINER_NAME | jq -r '.[]| ."HostsPath"' | xargs dirname)
-docker stop "$CONTAINER_NAME"
-jq --arg PORT "$WIREGUARD_PORT" --arg PORTSEL "${WIREGUARD_PORT}/udp" '(."PortBindings" | .[$PORTSEL] | .[] | ."HostPort" ) |= $PORT' "$CONTAINER_CONFIG_PATH/hostconfig.json" > "$CONTAINER_CONFIG_PATH/hostconfig.json.tmp"
+docker stop "$CONTAINER_NAME" 1>/dev/null 2>&1
+jq --arg PORT "$WIREGUARD_PORT" '(."PortBindings"."18521/udp"[] | ."HostPort" ) |= $PORT' "$CONTAINER_CONFIG_PATH/hostconfig.json" > "$CONTAINER_CONFIG_PATH/hostconfig.json.tmp"
 mv "$CONTAINER_CONFIG_PATH/hostconfig.json.tmp" "$CONTAINER_CONFIG_PATH/hostconfig.json"
-docker start "$CONTAINER_NAME"
+docker start "$CONTAINER_NAME" 1>/dev/null 2>&1
 
 # get public ipv4 address
 GATEWAY_IP=$(curl -s 4.icanhazip.com)

--- a/src/gateway-link/entrypoint.sh
+++ b/src/gateway-link/entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-WG_PRIVKEY=$(wg genkey)
-echo $WG_PRIVKEY > /etc/wireguard/link0.key
-
+# only generate a new key if link0.key is missing or empty
+if ! [[ -s /etc/wireguard/link0.key ]]; then
+    WG_PRIVKEY=$(wg genkey)
+    echo $WG_PRIVKEY > /etc/wireguard/link0.key
+fi
 
 ip link add link0 type wireguard
 


### PR DESCRIPTION
Uses the docker daemon to pick a free port automatically for the container as before, but then edit hostconfig.json to inject that chosen port into the container's static configuration (same as doing `-p port:port` instead of just `-p port`) 